### PR TITLE
Removed underscore.js dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -4,9 +4,6 @@ Package.describe({
   summary: "A markdown parser and compiler. Built for speed."
 });
 
-// XXX hack -- need a way to use a package at bundle time
-var _ = require('../../packages/underscore/underscore.js');
-
 Package.on_use(function (api, where) {
   where = where || ["client", "server"];
   where = where instanceof Array ? where : [where];
@@ -15,8 +12,7 @@ Package.on_use(function (api, where) {
 
   // XXX what we really want to do is, load template-integration after
   // handlebars, iff handlebars was included in the project.
-  if (where === "client" ||
-      (where instanceof Array && _.indexOf(where, "client") !== -1)) {
+  if (where === "client" || (where instanceof Array && where.indexOf("client") !== -1)) {
     api.use("handlebars", "client");
     api.add_files("template-integration.js", "client");
   }


### PR DESCRIPTION
I was working in a project without `mrt add underscore` and I was getting a error because of that.

I removed the underscore.js dependency by change the _.indexOf to Array.prototype.indexOf

PS: Sorry about possible english mistakes.
