### PR TITLE
Change `require` to `Npm.require`.

### DIFF
--- a/package.js
+++ b/package.js
@@ -5,7 +5,7 @@ Package.describe({
 });
 
 // XXX hack -- need a way to use a package at bundle time
-var _ = require('../../packages/underscore/underscore.js');
+var _ = Npm.require('../../packages/underscore/underscore.js');
 
 Package.on_use(function (api, where) {
   where = where || ["client", "server"];


### PR DESCRIPTION
Meteor 0.6.0 uses `Npm.require()`, not just `require()`. `require()` isn't defined, and using it throws an error.
