### PR TITLE
Fixed underscore require statement

### DIFF
--- a/package.js
+++ b/package.js
@@ -4,7 +4,6 @@ Package.describe({
   summary: "A markdown parser and compiler. Built for speed."
 });
 
-// XXX hack -- need a way to use a package at bundle time
 var _ = Npm.require('underscore');
 
 Package.on_use(function (api, where) {


### PR DESCRIPTION
This was breaking when using `mrt` instead of meteor
