### PR TITLE
respect meteor package namespacing

### DIFF
--- a/package.js
+++ b/package.js
@@ -11,6 +11,10 @@ Package.on_use(function (api) {
   api.versionsFrom("METEOR@0.9.1");
   api.use("templating", "client", {weak: true});
 
+  api.add_files("pre-marked.js");
   api.add_files("marked/lib/marked.js");
+  api.add_files("post-marked.js");
+
   api.add_files('template-integration.js', 'client');
+  api.export('marked');
 });

--- a/post-marked.js
+++ b/post-marked.js
@@ -1,0 +1,1 @@
+marked = module.exports;

--- a/pre-marked.js
+++ b/pre-marked.js
@@ -1,0 +1,2 @@
+exports = {};
+module = {};

--- a/versions.json
+++ b/versions.json
@@ -2,14 +2,14 @@
   "dependencies": [
     [
       "meteor",
-      "1.0.3"
+      "1.1.3"
     ],
     [
       "underscore",
-      "1.0.0"
+      "1.0.1"
     ]
   ],
   "pluginDependencies": [],
-  "toolVersion": "meteor-tool@1.0.27",
+  "toolVersion": "meteor-tool@1.0.35",
   "format": "1.0"
 }


### PR DESCRIPTION
hey, this is a very simple PR to make sure marked doesn't attach to window/global and instead works through meteor's namespacing.  that means, that, it will be available (always) via `Package['chuangbo:marked'].marked` and won't interfere with window/global when `{weak: true}` is used.  it also means the package will work with famono :), which currently breaks the package because of how `define` is used.
